### PR TITLE
"Show on Bosses" now makes Neat work on non-bosses

### DIFF
--- a/src/main/java/vazkii/neat/HealthBarRenderer.java
+++ b/src/main/java/vazkii/neat/HealthBarRenderer.java
@@ -202,7 +202,7 @@ public class HealthBarRenderer {
 				float distance = passedEntity.getDistance(viewPoint);
 				if (distance > NeatConfig.maxDistance || !passedEntity.canEntityBeSeen(viewPoint) || entity.isInvisible())
 					break processing;
-				if (!NeatConfig.showOnBosses && !boss)
+				if (!NeatConfig.showOnBosses && boss)
 					break processing;
 				if (!NeatConfig.showOnPlayers && entity instanceof PlayerEntity)
 					break processing;


### PR DESCRIPTION
Fixed the health bar not showing on mobs but bosses when "Show on Bosses" is disabled.
Fixes #35 