### PR TITLE
Fix healthbars blocked by nonliving passengers.

### DIFF
--- a/Xplat/src/main/java/vazkii/neat/HealthBarRenderer.java
+++ b/Xplat/src/main/java/vazkii/neat/HealthBarRenderer.java
@@ -191,7 +191,7 @@ public class HealthBarRenderer {
 			Quaternionf cameraOrientation) {
 		final Minecraft mc = Minecraft.getInstance();
 
-		if (!(entity instanceof LivingEntity living) || !living.getPassengers().isEmpty()) {
+		if (!(entity instanceof LivingEntity living) || (!living.getPassengers().isEmpty() && living.getPassengers().get(0) instanceof LivingEntity)) {
 			// TODO handle mob stacks properly
 			return;
 		}


### PR DESCRIPTION
This PR fixes an edge case where mobs that have a non-living passenger (such as a splash potion) will not render their healthbar.

Implementation tested on Fabric 1.20.1.

In more detail:  
Currently Neat does not render healthbars for mobs with passengers, but it also does not render healthbars for non-living entities. This creates the aforementioned edge case and render no healthbar for the mob-stack.  
I've added an extra condition to the passenger check, now if the first passenger of a mob is non-living, then the healthbar of that mob will still render.
